### PR TITLE
Adding command to Build Process of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ ObjectMakr uses [Gulp](http://gulpjs.com/) to automate building, which requires 
 To build from scratch, install NodeJS and run the following commands:
 
 ```
+npm install -g gulp-cli
 npm install
 gulp
 ```


### PR DESCRIPTION
Without this command, the error message 'gulp not found' will be a response to any attempt at a gulp command.